### PR TITLE
Add pagination to expenses list with Load More button

### DIFF
--- a/backend/create_test_expenses.go
+++ b/backend/create_test_expenses.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"freesplit/internal/database"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func main() {
+	// Get database URL from environment variable or use default
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		// Default to local PostgreSQL for development
+		databaseURL = "host=localhost user=postgres password=postgres dbname=freesplit port=5432 sslmode=disable"
+		log.Printf("🔧 Using local PostgreSQL for development")
+	} else {
+		log.Printf("🔧 Using DATABASE_URL from environment")
+	}
+
+	// Connect to database
+	db, err := gorm.Open(postgres.Open(databaseURL), &gorm.Config{})
+	if err != nil {
+		log.Fatalf("Failed to connect to database: %v", err)
+	}
+	log.Printf("✅ Successfully connected to database")
+
+	// Run migrations
+	if err := database.Migrate(db); err != nil {
+		log.Fatalf("Failed to migrate database: %v", err)
+	}
+
+	// Create test group
+	group := database.Group{
+		Name:     "Test Pagination Group",
+		URLSlug:  fmt.Sprintf("test-pagination-%d", time.Now().Unix()),
+		Currency: "USD",
+		State:    "active",
+	}
+
+	if err := db.Create(&group).Error; err != nil {
+		log.Fatalf("Failed to create group: %v", err)
+	}
+	log.Printf("✅ Created group: %s (ID: %d)", group.Name, group.ID)
+
+	// Create participants
+	participant1 := database.Participant{
+		Name:   "Alice",
+		GroupID: group.ID,
+	}
+	participant2 := database.Participant{
+		Name:   "Bob",
+		GroupID: group.ID,
+	}
+
+	if err := db.Create(&participant1).Error; err != nil {
+		log.Fatalf("Failed to create participant 1: %v", err)
+	}
+	if err := db.Create(&participant2).Error; err != nil {
+		log.Fatalf("Failed to create participant 2: %v", err)
+	}
+	log.Printf("✅ Created participants: %s (ID: %d), %s (ID: %d)", participant1.Name, participant1.ID, participant2.Name, participant2.ID)
+
+	// Create 51 expenses
+	baseTime := time.Now()
+	for i := 0; i < 51; i++ {
+		// Create expense with different timestamps to ensure proper ordering
+		expense := database.Expense{
+			Name:      fmt.Sprintf("Expense %d", i),
+			Cost:      10.00,
+			Emoji:     "💰",
+			PayerID:   participant1.ID,
+			SplitType: "equal",
+			GroupID:   group.ID,
+			CreatedAt: baseTime.Add(time.Duration(i) * time.Second),
+			UpdatedAt: baseTime.Add(time.Duration(i) * time.Second),
+		}
+
+		if err := db.Create(&expense).Error; err != nil {
+			log.Fatalf("Failed to create expense %d: %v", i, err)
+		}
+
+		// Create splits for this expense (equal split between both participants)
+		split1 := database.Split{
+			GroupID:       group.ID,
+			ExpenseID:     expense.ID,
+			ParticipantID: participant1.ID,
+			SplitAmount:   5.00,
+		}
+		split2 := database.Split{
+			GroupID:       group.ID,
+			ExpenseID:     expense.ID,
+			ParticipantID: participant2.ID,
+			SplitAmount:   5.00,
+		}
+
+		if err := db.Create(&split1).Error; err != nil {
+			log.Fatalf("Failed to create split 1 for expense %d: %v", i, err)
+		}
+		if err := db.Create(&split2).Error; err != nil {
+			log.Fatalf("Failed to create split 2 for expense %d: %v", i, err)
+		}
+
+		if (i+1)%10 == 0 {
+			log.Printf("✅ Created %d expenses...", i+1)
+		}
+	}
+
+	log.Printf("✅ Successfully created 51 expenses for group '%s'", group.Name)
+	log.Printf("📋 Group URL slug: %s", group.URLSlug)
+	log.Printf("🎉 Test data creation complete!")
+}
+

--- a/backend/internal/services/expense_service.go
+++ b/backend/internal/services/expense_service.go
@@ -9,6 +9,8 @@ import (
 	"gorm.io/gorm"
 )
 
+const EXPENSES_PER_PAGE = 50
+
 type expenseService struct {
 	db *gorm.DB
 }
@@ -22,12 +24,30 @@ func NewExpenseService(db *gorm.DB) ExpenseService {
 }
 
 // GetExpensesByGroup retrieves expenses for a specific group ordered by creation date.
-// Input: GetExpensesByGroupRequest containing GroupId
-// Output: GetExpensesByGroupResponse with list of expenses
-// Description: Fetches expenses for a group in descending order by creation date, with a minimum limit of 50
+// Input: GetExpensesByGroupRequest containing GroupId, Offset, and Limit
+// Output: GetExpensesByGroupResponse with list of expenses and pagination info
+// Description: Fetches expenses for a group in descending order by creation date with pagination support
 func (s *expenseService) GetExpensesByGroup(ctx context.Context, req *GetExpensesByGroupRequest) (*GetExpensesByGroupResponse, error) {
+	// Set default limit if not provided
+	limit := req.Limit
+	if limit <= 0 {
+		limit = EXPENSES_PER_PAGE
+	}
+
+	offset := req.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	// Count total expenses for the group
+	var totalRecords int64
+	if err := s.db.Model(&database.Expense{}).Where("group_id = ?", req.GroupId).Count(&totalRecords).Error; err != nil {
+		return nil, fmt.Errorf("failed to count expenses: %v", err)
+	}
+
+	// Fetch expenses with pagination
 	var expenses []database.Expense
-	if err := s.db.Where("group_id = ?", req.GroupId).Order("created_at DESC").Limit(50).Find(&expenses).Error; err != nil {
+	if err := s.db.Where("group_id = ?", req.GroupId).Order("created_at DESC").Offset(int(offset)).Limit(int(limit)).Find(&expenses).Error; err != nil {
 		return nil, fmt.Errorf("failed to get expenses: %v", err)
 	}
 
@@ -37,7 +57,10 @@ func (s *expenseService) GetExpensesByGroup(ctx context.Context, req *GetExpense
 	}
 
 	return &GetExpensesByGroupResponse{
-		Expenses: responseExpenses,
+		Data: responseExpenses,
+		Pagination: GetExpensesPagination{
+			TotalRecords: int32(totalRecords),
+		},
 	}, nil
 }
 

--- a/backend/internal/services/types.go
+++ b/backend/internal/services/types.go
@@ -62,10 +62,17 @@ type DeleteParticipantRequest struct {
 // Request and Response types for Expense operations
 type GetExpensesByGroupRequest struct {
 	GroupId int32 `json:"group_id"`
+	Offset  int32 `json:"offset,omitempty"`
+	Limit   int32 `json:"limit,omitempty"`
 }
 
 type GetExpensesByGroupResponse struct {
-	Expenses []*Expense `json:"expenses"`
+	Data       []*Expense           `json:"data"`
+	Pagination GetExpensesPagination `json:"pagination"`
+}
+
+type GetExpensesPagination struct {
+	TotalRecords int32 `json:"total_records"`
 }
 
 type CreateExpenseRequest struct {

--- a/backend/rest_server.go
+++ b/backend/rest_server.go
@@ -507,8 +507,27 @@ func getExpensesByGroup(w http.ResponseWriter, r *http.Request, expenseService s
 		return
 	}
 
+	// Parse query parameters for pagination
+	query := r.URL.Query()
+	offset := int32(0)
+	limit := int32(0)
+
+	if offsetStr := query.Get("offset"); offsetStr != "" {
+		if parsedOffset, err := strconv.Atoi(offsetStr); err == nil && parsedOffset >= 0 {
+			offset = int32(parsedOffset)
+		}
+	}
+
+	if limitStr := query.Get("limit"); limitStr != "" {
+		if parsedLimit, err := strconv.Atoi(limitStr); err == nil && parsedLimit > 0 {
+			limit = int32(parsedLimit)
+		}
+	}
+
 	serviceReq := &services.GetExpensesByGroupRequest{
 		GroupId: int32(groupID),
+		Offset:  offset,
+		Limit:   limit,
 	}
 
 	resp, err := expenseService.GetExpensesByGroup(context.TODO(), serviceReq)
@@ -519,7 +538,7 @@ func getExpensesByGroup(w http.ResponseWriter, r *http.Request, expenseService s
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp.Expenses)
+	json.NewEncoder(w).Encode(resp)
 }
 
 func getSplitsByGroup(w http.ResponseWriter, r *http.Request, expenseService services.ExpenseService) {

--- a/frontend/src/pages/GroupDashboard.tsx
+++ b/frontend/src/pages/GroupDashboard.tsx
@@ -227,7 +227,6 @@ const GroupDashboard: React.FC = () => {
                       onClick={loadMoreExpenses}
                       disabled={loadingMore}
                       className="btn"
-                      style={{ width: '100%' }}
                     >
                       {loadingMore ? 'Loading...' : 'Load More...'}
                     </button>

--- a/frontend/src/pages/GroupDashboard.tsx
+++ b/frontend/src/pages/GroupDashboard.tsx
@@ -14,6 +14,8 @@ import { faReceipt, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import FreesplitLogo from '../images/FreeSplit.svg';
 import { ring } from 'ldrs'; ring.register();
 
+const EXPENSES_PER_PAGE = 50;
+
 const formatAmount = (value: number): string => {
   if (!Number.isFinite(value)) {
     return '0.00';
@@ -34,6 +36,9 @@ const GroupDashboard: React.FC = () => {
   const [expenses, setExpenses] = useState<Expense[]>([]);
   const [loading, setLoading] = useState(true);
   const [isWelcomeOpen, setWelcomeOpen] = useState(false);
+  const [totalRecords, setTotalRecords] = useState<number>(0);
+  const [loadingMore, setLoadingMore] = useState<boolean>(false);
+  const [currentOffset, setCurrentOffset] = useState<number>(0);
 
   // Track group visit for user groups feature
   useGroupTracking();
@@ -44,17 +49,36 @@ const GroupDashboard: React.FC = () => {
       setLoading(true);
       const groupResponse = await getGroup(urlSlug!);
       
-      const expensesResponse = await getExpensesByGroup(groupResponse.group.id);
+      const expensesResponse = await getExpensesByGroup(groupResponse.group.id, 0, EXPENSES_PER_PAGE);
 
       setGroup(groupResponse.group);
       setParticipants(groupResponse.participants);
-      setExpenses(expensesResponse);
+      setExpenses(expensesResponse.data);
+      setTotalRecords(expensesResponse.pagination.total_records);
+      setCurrentOffset(EXPENSES_PER_PAGE);
     } catch (error) {
       console.error('Error loading group data:', error);
     } finally {
       setLoading(false);
     }
   }, [urlSlug]);
+
+  const loadMoreExpenses = useCallback(async () => {
+    if (!group || loadingMore) return;
+    
+    try {
+      setLoadingMore(true);
+      const expensesResponse = await getExpensesByGroup(group.id, currentOffset, EXPENSES_PER_PAGE);
+      
+      setExpenses(prev => [...prev, ...expensesResponse.data]);
+      setCurrentOffset(prev => prev + EXPENSES_PER_PAGE);
+    } catch (error) {
+      console.error('Error loading more expenses:', error);
+      toast.error('Failed to load more expenses');
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [group, currentOffset, loadingMore]);
 
   useEffect(() => {
     if (urlSlug) {
@@ -90,9 +114,11 @@ const GroupDashboard: React.FC = () => {
       try {
         await deleteExpense(expenseId);
         toast.success('Expense deleted successfully');
-        // Reload expenses
-        const expensesResponse = await getExpensesByGroup(group!.id);
-        setExpenses(expensesResponse);
+        // Reload expenses from the beginning
+        const expensesResponse = await getExpensesByGroup(group!.id, 0, EXPENSES_PER_PAGE);
+        setExpenses(expensesResponse.data);
+        setTotalRecords(expensesResponse.pagination.total_records);
+        setCurrentOffset(EXPENSES_PER_PAGE);
       } catch (error) {
         toast.error('Failed to delete expense');
         console.error('Error deleting expense:', error);
@@ -195,6 +221,18 @@ const GroupDashboard: React.FC = () => {
                     </button>
                   ))}
                 </div>
+                {expenses.length < totalRecords && (
+                  <div className="content-container text-is-centered" style={{ marginTop: '16px' }}>
+                    <button
+                      onClick={loadMoreExpenses}
+                      disabled={loadingMore}
+                      className="btn"
+                      style={{ width: '100%' }}
+                    >
+                      {loadingMore ? 'Loading...' : 'Load More...'}
+                    </button>
+                  </div>
+                )}
                 </>
               )}
             </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -230,8 +230,20 @@ export const deleteParticipant = async (participantId: number): Promise<void> =>
 };
 
 // Expense API
-export const getExpensesByGroup = async (groupId: number): Promise<Expense[]> => {
-  const response = await axios.get(`${API_BASE_URL}/api/group/${groupId}/expenses`);
+export interface GetExpensesResponse {
+  data: Expense[];
+  pagination: {
+    total_records: number;
+  };
+}
+
+export const getExpensesByGroup = async (groupId: number, offset: number = 0, limit: number = 50): Promise<GetExpensesResponse> => {
+  const response = await axios.get(`${API_BASE_URL}/api/group/${groupId}/expenses`, {
+    params: {
+      offset,
+      limit
+    }
+  });
   return response.data;
 };
 


### PR DESCRIPTION
## Summary
This PR adds pagination support to the expenses list, allowing users to load expenses in batches of 50 with a "Load More..." button.

## Changes

### Backend
- Added `EXPENSES_PER_PAGE = 50` constant
- Updated `GetExpensesByGroupRequest` to support `offset` and `limit` parameters
- Modified response structure to `{data: [], pagination: {total_records: N}}`
- Updated REST handler to parse query parameters for pagination
- Service method now counts total records and applies offset/limit

### Frontend
- Added `EXPENSES_PER_PAGE = 50` constant
- Updated API function to accept offset/limit and return new response structure
- Implemented continuous loading: expenses append to existing list
- Added "Load More..." button that appears centered below expenses when more records exist
- Button shows loading state while fetching
- Tracks total records to determine if more expenses are available

### Testing
- Created test script (`create_test_expenses.go`) to generate test group with 51 expenses
- Test group created successfully with expenses named "Expense 0" through "Expense 50"

## Screenshot
Please add a screenshot showing:
- The expenses list with the "Load More..." button visible below
- The button should be centered and sized to fit the text (not full width)

## Testing
- Test with the test group created by `create_test_expenses.go`
- Verify first 50 expenses load initially
- Click "Load More..." to load remaining expenses
- Verify expenses append to the list (continuous loading)
- Verify button disappears when all expenses are loaded

<img width="736" height="527" alt="image" src="https://github.com/user-attachments/assets/92ea42aa-4b68-4566-b037-b82a6a23d436" />
